### PR TITLE
Add an option to load dummy data for demo purposes

### DIFF
--- a/src/components/accounts/AddAccountDialog.js
+++ b/src/components/accounts/AddAccountDialog.js
@@ -76,6 +76,7 @@ class AddAccountDialog extends React.Component {
 
       if (!this.props.rates[this.state.currency]) {
         this.props.fetchRates(this.state.currency)
+        this.props.fetchRates(this.props.defaultCurrency)
       }
 
       this.props.addAccount({

--- a/src/components/accounts/Details.js
+++ b/src/components/accounts/Details.js
@@ -15,6 +15,7 @@ import Divider from '@material-ui/core/Divider'
 import DepositDialog from './DepositDialog'
 import WithdrawDialog from './WithdrawDialog'
 import TransferDialog from './TransferDialog'
+import { fetchRates } from '../../redux/actions'
 
 const styles = (theme) => ({
   root: {
@@ -34,7 +35,11 @@ const styles = (theme) => ({
   }
 })
 
-const Details = ({ account, classes, hasOtherAccounts, rates }) => {
+const Details = ({ account, classes, fetchRates, hasOtherAccounts, rates }) => {
+  if (!rates[account.currency]) {
+    fetchRates(account.currency)
+  }
+
   const currencyRatesArr = Object.entries(rates[account.currency] || {}).sort((a, b) => {
     return a[0] > b[0] ? 1 : -1
   })
@@ -89,6 +94,7 @@ const Details = ({ account, classes, hasOtherAccounts, rates }) => {
 Details.propTypes = {
   account: PropTypes.object.isRequired,
   classes: PropTypes.object.isRequired,
+  fetchRates: PropTypes.func.isRequired,
   hasOtherAccounts: PropTypes.bool.isRequired,
   match: PropTypes.object.isRequired,
   rates: PropTypes.object.isRequired,
@@ -102,5 +108,5 @@ const mapStateToProps = (state, ownProps) => ({
 
 export default compose(
   withStyles(styles),
-  connect(mapStateToProps, {  }),
+  connect(mapStateToProps, { fetchRates }),
 )(Details)

--- a/src/components/accounts/GroupItem.js
+++ b/src/components/accounts/GroupItem.js
@@ -3,18 +3,16 @@ import { connect } from 'react-redux'
 import { compose } from 'recompose'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
+import Collapse from '@material-ui/core/Collapse'
 import Divider from '@material-ui/core/Divider'
+import ExpandLess from '@material-ui/icons/ExpandLess'
+import ExpandMore from '@material-ui/icons/ExpandMore'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 
-
-import Collapse from '@material-ui/core/Collapse'
-import ExpandLess from '@material-ui/icons/ExpandLess'
-import ExpandMore from '@material-ui/icons/ExpandMore'
-
 import AccountItem from './AccountItem'
-import { getTotalBalance } from '../../lib/helpers'
+import TotalBalanceOrProgress from '../common/TotalBalanceOrProgress'
 import { toggleGroup } from '../../redux/actions'
 
 const styles = (theme) => ({
@@ -33,7 +31,7 @@ class GroupItem extends React.Component {
   }
 
   render() {
-    const { accounts, rates, classes, defaultCurrency, group } = this.props
+    const { accounts, classes, group } = this.props
 
     return (
       <>
@@ -43,7 +41,7 @@ class GroupItem extends React.Component {
             <ListItem button onClick={this.handleClick}>
               <ListItemText primary={group.name} />
               <span className={classes.total}>
-                {getTotalBalance(accounts, rates, defaultCurrency)}
+                <TotalBalanceOrProgress accounts={accounts} />
               </span>
               {group.collapsed ? <ExpandMore /> : <ExpandLess />}
             </ListItem>
@@ -68,18 +66,14 @@ class GroupItem extends React.Component {
 GroupItem.propTypes = {
   accounts: PropTypes.array.isRequired,
   classes: PropTypes.object.isRequired,
-  defaultCurrency: PropTypes.string.isRequired,
   group: PropTypes.object.isRequired,
-  rates: PropTypes.object.isRequired,
   toggleGroup: PropTypes.func.isRequired,
 }
 
 const mapStateToProps = (state, ownProps) => ({
   accounts: state.accounts.filter((account) => {
     return account.groupId === ownProps.group.id
-  }).sort((a, b) => a.name > b.name ? 1 : -1),
-  defaultCurrency: state.settings.defaultCurrency,
-  rates: state.rates
+  }).sort((a, b) => a.name > b.name ? 1 : -1)
 })
 
 export default compose(

--- a/src/components/accounts/GroupList.js
+++ b/src/components/accounts/GroupList.js
@@ -1,15 +1,18 @@
+import moment from 'moment'
 import React from 'react'
 import { connect } from 'react-redux'
 import { compose } from 'recompose'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
+import Button from '@material-ui/core/Button'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
 import Typography from '@material-ui/core/Typography'
 
 import GroupItem from './GroupItem'
-import { getTotalBalance } from '../../lib/helpers'
+import TotalBalanceOrProgress from '../common/TotalBalanceOrProgress'
+import { addHistory, fetchRates, loadDemoData } from '../../redux/actions'
 
 
 const styles = (theme) => ({
@@ -21,48 +24,77 @@ const styles = (theme) => ({
   total: {
     fontWeight: 'bold',
     paddingRight: theme.spacing.unit * 7
+  },
+  loadButton: {
+    ...theme.typography.subtitle1,
+    textTransform: 'none',
+    textDecoration: 'underline',
+    padding: 0,
+    minWidth: 'auto',
+    color: '#0000EE',
+
+    '&:hover': {
+      backgroundColor: 'transparent'
+    }
   }
 })
 
-const GroupList = ({ classes, groups, hasAccounts, total }) => (
-  <>
-    { hasAccounts ?
-      <List component="nav">
-        {groups.map((group) =>
-          <GroupItem key={group.id} group={group} />
-        )}
-        <ListItem className={classes.total}>
-          <ListItemText primary="Total" disableTypography={true} />
-          {total}
-        </ListItem>
-      </List>
-      :
-      <>
-        <Typography variant="h5" className={classes.empty} >
-          Your wallet is empty.
-        </Typography>
-        <Typography variant="h5" className={classes.empty} >
-          Add some accounts from the top menu.
-        </Typography>
-      </>
-    }
-  </>
-)
+const GroupList = ({ addHistory, classes, groups, hasAccounts, loadDemoData, fetchRates }) => {
+  const handleOnClick = (e) => {
+    loadDemoData()
+    fetchRates('USD')
+    addHistory({
+      text: 'Loaded the wallet with the demo data',
+      date: moment().format()
+    })
+  }
+
+  return (
+    <>
+      { hasAccounts ?
+        <List component="nav">
+          {groups.map((group) =>
+            <GroupItem key={group.id} group={group} />
+          )}
+          <ListItem className={classes.total}>
+            <ListItemText primary="Total" disableTypography={true} />
+            <TotalBalanceOrProgress />
+          </ListItem>
+        </List>
+        :
+        <>
+          <Typography variant="h5" className={classes.empty} >
+            Your wallet is empty
+          </Typography>
+          <Typography variant="subtitle1" className={classes.empty} >
+            Add accounts from the top menu or<br/>
+            <Button color="primary" onClick={handleOnClick} className={classes.loadButton}>
+              load
+            </Button>
+            &nbsp;
+            some dummy data for demo purposes
+          </Typography>
+        </>
+      }
+    </>
+  )
+}
 
 GroupList.propTypes = {
+  addHistory: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,
+  fetchRates: PropTypes.func.isRequired,
   groups: PropTypes.array.isRequired,
   hasAccounts: PropTypes.bool.isRequired,
-  total: PropTypes.string.isRequired
+  loadDemoData: PropTypes.func.isRequired
 }
 
 const mapStateToProps = (state) => ({
   hasAccounts: state.accounts.length > 0,
-  groups: state.groups,
-  total: getTotalBalance(state.accounts, state.rates, state.settings.defaultCurrency)
+  groups: state.groups
 })
 
 export default compose(
   withStyles(styles),
-  connect(mapStateToProps)
+  connect(mapStateToProps, { addHistory, fetchRates, loadDemoData })
 )(GroupList)

--- a/src/components/accounts/GroupList.test.js
+++ b/src/components/accounts/GroupList.test.js
@@ -17,7 +17,7 @@ it('renders with no accounts', async () => {
       </Router>
     </Provider>
   )
-  expect(queryByText('Your wallet is empty.')).toBeTruthy()
+  expect(queryByText('Your wallet is empty')).toBeTruthy()
   expect(queryByText('Total')).toBeNull()
 })
 
@@ -54,5 +54,5 @@ it('renders with accounts', async () => {
   expect(queryByText('10.00 BGN')).toBeTruthy()
   expect(queryByText('Total')).toBeTruthy()
   expect(queryByText('20.00 BGN')).toBeTruthy()
-  expect(queryByText('Your wallet is empty.')).toBeNull()
+  expect(queryByText('Your wallet is empty')).toBeNull()
 })

--- a/src/components/common/TotalBalanceOrProgress.js
+++ b/src/components/common/TotalBalanceOrProgress.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+import CircularProgress from '@material-ui/core/CircularProgress'
+
+import { getTotalBalance } from '../../lib/helpers'
+
+const TotalBalanceOrProgress = ({ total }) =>  (
+  <>
+    {
+      ~total.indexOf('NaN') ?
+      <CircularProgress size={20} /> :
+      total
+    }
+  </>
+)
+
+TotalBalanceOrProgress.propTypes = {
+  total: PropTypes.string.isRequired
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const accounts = ownProps.accounts || state.accounts
+  return {
+    total: getTotalBalance(accounts, state.rates, state.settings.defaultCurrency)
+  }
+}
+
+export default connect(mapStateToProps)(TotalBalanceOrProgress)

--- a/src/components/error/ErrorPage.js
+++ b/src/components/error/ErrorPage.js
@@ -6,15 +6,20 @@ import Typography from '@material-ui/core/Typography'
 
 const styles = (theme) => ({
   empty: {
-    padding: theme.spacing.unit * 3,
+    paddingTop: theme.spacing.unit * 3,
     textAlign: 'center'
   }
 })
 
 const ErrorPage = ({ classes }) => (
-  <Typography variant="h5" className={classes.empty} >
-    Page not found. You can start from <Link to="/">here</Link>.
-  </Typography>
+  <>
+    <Typography variant="h5" className={classes.empty} >
+      Page not found
+    </Typography>
+    <Typography variant="subtitle1" className={classes.empty} >
+      You can start from <Link to="/">here</Link>
+    </Typography>
+  </>
 )
 
 ErrorPage.propTypes = {

--- a/src/components/history/HistoryList.js
+++ b/src/components/history/HistoryList.js
@@ -37,10 +37,10 @@ const HistoryList = ({ classes, history }) => (
     :
     <>
       <Typography variant="h5" className={classes.empty} >
-        Your history is empty.
+        Your history is empty
       </Typography>
-      <Typography variant="h5" className={classes.empty} >
-        Add some accounts and make some transfers to populate the list.
+      <Typography variant="subtitle1" className={classes.empty} >
+        Add some accounts and make some transfers to populate the list
       </Typography>
     </>
 )

--- a/src/components/history/HistoryList.test.js
+++ b/src/components/history/HistoryList.test.js
@@ -14,7 +14,7 @@ it('renders with no history', async () => {
       <HistoryList />
     </Provider>
   )
-  expect(queryByText('Your history is empty.')).toBeTruthy()
+  expect(queryByText('Your history is empty')).toBeTruthy()
   expect(queryByText('Added new account')).toBeNull()
 })
 
@@ -30,6 +30,6 @@ it('renders with history', async () => {
       <HistoryList />
     </Provider>
   )
-  expect(queryByText('Your history is empty.')).toBeNull()
+  expect(queryByText('Your history is empty')).toBeNull()
   expect(queryByText('Added new account')).toBeTruthy()
 })

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -17,6 +17,10 @@ export const resetData = () => ({
   type: 'RESET_DATA'
 })
 
+export const loadDemoData = () => ({
+  type: 'LOAD_DEMO_DATA'
+})
+
 export const changeDefaultCurrency = (payload) => ({
   type: 'CHANGE_DEFAULT_CURRENCY',
   payload

--- a/src/redux/reducers/groups.js
+++ b/src/redux/reducers/groups.js
@@ -2,9 +2,8 @@ import { uniqueId } from '../../lib/helpers'
 
 const initialState = [
   'Cash',
-  'Bank Accounts',
-  'Cards',
-  'Credit Cards',
+  'Cards & Bank Accounts',
+  'Debts',
   'Investments',
   'Others'
 ].map((name) => ({

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -5,6 +5,7 @@ import groups from './groups'
 import history from './history'
 import rates from './rates'
 import settings from './settings'
+import { uniqueId } from '../../lib/helpers'
 
 const allReducers = combineReducers({
   accounts,
@@ -18,6 +19,33 @@ export default (state, action) => {
   if (action.type === 'RESET_DATA') {
     // not a state mutation, just reassigning the ref of the local var state
     state = undefined
+  }
+
+  if (action.type === 'LOAD_DEMO_DATA') {
+    state = {
+      ...state,
+      accounts: [
+        // Cash
+        { name: 'Wallet', id: uniqueId(), currency: 'USD', value: 500, groupId: state.groups[0].id },
+        { name: 'Travel Change', id: uniqueId(), currency: 'EUR', value: 95, groupId: state.groups[0].id },
+
+        // Cards & Bank Accounts
+        { name: 'Debit Card', id: uniqueId(), currency: 'USD', value: 8500, groupId: state.groups[1].id },
+        { name: 'TransferWise', id: uniqueId(), currency: 'USD', value: 1500, groupId: state.groups[1].id },
+        { name: 'Canadian Account', id: uniqueId(), currency: 'CAD', value: 500, groupId: state.groups[1].id },
+
+        // Investments
+        { name: 'P2P Lending', id: uniqueId(), currency: 'EUR', value: 5000, groupId: state.groups[3].id },
+        { name: 'Stocks', id: uniqueId(), currency: 'USD', value: 5000, groupId: state.groups[3].id },
+        { name: 'Crypto funds', id: uniqueId(), currency: 'USD', value: 5000, groupId: state.groups[3].id },
+
+        // Other Accounts
+        { name: 'PayPal', id: uniqueId(), currency: 'USD', value: 500, groupId: state.groups[4].id }
+      ],
+      settings: {
+        defaultCurrency: 'USD'
+      }
+    }
   }
 
   return allReducers(state, action)


### PR DESCRIPTION
If the wallet is empty the homepage will show a "Load" button
that adds some data for easier demos.

Other tweaks:
- improved the typography;
- made sure the currency exchange rates are updated and fetched
when necessary;
- added a progress loader in place of the total balance when adding
accounts with new currencies and their rates are not fetched yet.