### PR TITLE
Normalize redux store for accounts and groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ All actions and data are saved in the `localStorage` so that everything is avail
 
 Tests are incomplete and shown just as an example.
 
+**Dev note**: Because the app is deployed in Github Pages as a user page (i.e. `https://reactwallet.github.io` rather than `https://ishristov.github.io/reactwallet`) the page must be served from the `master` branch. That's the reason the source files are currently in the `source` branch and the `master` contains the `build` folder that is generated after running `npm run build`.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,11 +4,12 @@ import { connect } from 'react-redux'
 
 import RouterMap from './RouterMap'
 import { fetchRates } from '../redux/actions'
+import { getAllAccounts } from '../redux/reducers/accounts'
 
 class App extends Component {
   componentDidMount() {
     const currencies = this.props.accounts.map((a) => a.currency)
-    if ([...new Set(currencies)] > 1) {
+    if ([...new Set(currencies)].length > 1) {
       this.props.fetchRates(this.props.defaultCurrency)
     }
   }
@@ -27,7 +28,7 @@ App.propTypes = {
 }
 
 const mapStateToProps = (state) => ({
-  accounts: state.accounts,
+  accounts: getAllAccounts(state.accounts),
   defaultCurrency: state.settings.defaultCurrency
 })
 

--- a/src/components/accounts/AddAccountDialog.js
+++ b/src/components/accounts/AddAccountDialog.js
@@ -16,6 +16,7 @@ import TextField from '@material-ui/core/TextField'
 import { ALL_CURRENCIES } from '../../lib/constants'
 import { uniqueId } from '../../lib/helpers'
 import { addAccount, addHistory, fetchRates, changeDefaultCurrency } from '../../redux/actions'
+import { getAllGroups } from '../../redux/reducers/groups'
 
 const styles = (theme) => ({
   fab: {
@@ -218,9 +219,9 @@ AddAccountDialog.propTypes = {
 }
 
 const mapStateToProps = (state) => ({
-  hasAccounts: Boolean(state.accounts.length),
+  hasAccounts: state.accounts.allIds.length > 0,
   defaultCurrency: state.settings.defaultCurrency,
-  groups: state.groups,
+  groups: getAllGroups(state.groups),
   rates: state.rates
 })
 

--- a/src/components/accounts/DeleteAccountDialog.js
+++ b/src/components/accounts/DeleteAccountDialog.js
@@ -40,7 +40,7 @@ class DeleteAccountDialog extends React.Component {
   }
 
   handleSubmit = () => {
-    this.props.deleteAccount(this.props.account.id)
+    this.props.deleteAccount(this.props.account)
 
     this.props.addHistory({
       text: `Removed account ${this.props.account.name}`,

--- a/src/components/accounts/DepositDialog.js
+++ b/src/components/accounts/DepositDialog.js
@@ -52,7 +52,7 @@ class DepositDialog extends React.Component {
     })
 
     this.props.addHistory({
-      text: `Deposited ${this.state.value} ${this.props.account.currency} to\
+      text: `Deposited ${this.state.value} ${this.props.account.currency} to \
         ${this.props.account.name}`,
       date: moment().format()
     })

--- a/src/components/accounts/Details.js
+++ b/src/components/accounts/Details.js
@@ -21,6 +21,7 @@ import EditAccountDialog from './EditAccountDialog'
 import WithdrawDialog from './WithdrawDialog'
 import TransferDialog from './TransferDialog'
 import { fetchRates } from '../../redux/actions'
+import { getAllAccounts } from '../../redux/reducers/accounts'
 
 const styles = (theme) => ({
   listSubheader: {
@@ -47,7 +48,7 @@ const styles = (theme) => ({
   }
 })
 
-const Details = ({ account, classes, fetchRates, hasOtherAccounts, rates }) => {
+const Details = ({ account, classes, fetchRates, groups, hasOtherAccounts, rates }) => {
   if (!account.id) {
     return (<ErrorPage />)
   } else {
@@ -72,6 +73,11 @@ const Details = ({ account, classes, fetchRates, hasOtherAccounts, rates }) => {
         <ListItem>
           <ListItemText primary="Account" className={classes.term} />
           <ListItemText primary={account.name} primaryTypographyProps={{className: classes.desc}} />
+        </ListItem>
+        <Divider />
+        <ListItem>
+          <ListItemText primary="Group" className={classes.term} />
+          <ListItemText primary={(groups.byId[account.groupId]).name} primaryTypographyProps={{className: classes.desc}} />
         </ListItem>
         <Divider/>
         <ListItem>
@@ -124,11 +130,12 @@ Details.propTypes = {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  account: state.accounts.find((a) => {
+  account: getAllAccounts(state.accounts).find((a) => {
     return a.id === ownProps.match.params.accountId
   }) || {},
-  hasOtherAccounts: state.accounts.length > 1,
-  rates: state.rates
+  hasOtherAccounts: state.accounts.allIds.length > 1,
+  rates: state.rates,
+  groups: state.groups
 })
 
 export default compose(

--- a/src/components/accounts/EditAccountDialog.js
+++ b/src/components/accounts/EditAccountDialog.js
@@ -14,6 +14,7 @@ import IconButton from '@material-ui/core/IconButton'
 import TextField from '@material-ui/core/TextField'
 
 import { editAccount, addHistory } from '../../redux/actions'
+import { getAllGroups } from '../../redux/reducers/groups'
 
 const styles = (theme) => ({
   dialog: {
@@ -160,7 +161,7 @@ EditAccountDialog.propTypes = {
 }
 
 const mapStateToProps = (state) => ({
-  groups: state.groups
+  groups: getAllGroups(state.groups)
 })
 
 export default compose(

--- a/src/components/accounts/GroupItem.js
+++ b/src/components/accounts/GroupItem.js
@@ -14,6 +14,7 @@ import ListItemText from '@material-ui/core/ListItemText'
 import AccountItem from './AccountItem'
 import TotalBalanceOrProgress from '../common/TotalBalanceOrProgress'
 import { toggleGroup } from '../../redux/actions'
+import { getAllAccounts } from '../../redux/reducers/accounts'
 
 const styles = (theme) => ({
   total: {
@@ -74,7 +75,7 @@ GroupItem.propTypes = {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  accounts: state.accounts.filter((account) => {
+  accounts: getAllAccounts(state.accounts).filter((account) => {
     return account.groupId === ownProps.group.id
   }).sort((a, b) => a.name > b.name ? 1 : -1)
 })

--- a/src/components/accounts/GroupList.js
+++ b/src/components/accounts/GroupList.js
@@ -16,6 +16,7 @@ import GroupItem from './GroupItem'
 import Notice from '../common/Notice'
 import TotalBalanceOrProgress from '../common/TotalBalanceOrProgress'
 import { addHistory, fetchRates, loadDemoData } from '../../redux/actions'
+import { getAllGroups } from '../../redux/reducers/groups'
 
 const styles = (theme) => ({
   total: {
@@ -87,8 +88,8 @@ GroupList.propTypes = {
 }
 
 const mapStateToProps = (state) => ({
-  hasAccounts: state.accounts.length > 0,
-  groups: state.groups
+  hasAccounts: state.accounts.allIds.length > 0,
+  groups: getAllGroups(state.groups)
 })
 
 export default compose(

--- a/src/components/accounts/GroupList.test.js
+++ b/src/components/accounts/GroupList.test.js
@@ -23,13 +23,19 @@ it('renders with no accounts', async () => {
 
 it('renders with accounts', async () => {
   const store = createStore(reducer, {
-    accounts: [
-      { name: 'acc 1', id: '_a1', currency: 'BGN', value: 10, groupId: '_g1' },
-      { name: 'acc 2', id: '_a2', currency: 'EUR', value: 5, groupId: '_g1' }
-    ],
-    groups: [
-      { id: '_g1', name: 'Cash' }
-    ],
+    accounts: {
+      byId: {
+        _a1: { name: 'acc 1', id: '_a1', currency: 'BGN', value: 10, groupId: '_g1' },
+        _a2: { name: 'acc 2', id: '_a2', currency: 'EUR', value: 5, groupId: '_g1' }
+      },
+      allIds: ['_a1', '_a2']
+    },
+    groups: {
+      byId: {
+        _g1: { id: '_g1', name: 'Cash' }
+      },
+      allIds: ['_g1']
+    },
     rates: {
       EUR: {
         BGN: 2

--- a/src/components/accounts/TransferDialog.js
+++ b/src/components/accounts/TransferDialog.js
@@ -14,6 +14,7 @@ import DialogTitle from '@material-ui/core/DialogTitle'
 import TextField from '@material-ui/core/TextField'
 
 import { makeTransfer, addHistory } from '../../redux/actions'
+import { getAllAccounts } from '../../redux/reducers/accounts'
 
 const styles = (theme) => ({
   dialog: {
@@ -182,7 +183,7 @@ TransferDialog.propTypes = {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  accounts: state.accounts.filter((a) => {
+  accounts: getAllAccounts(state.accounts).filter((a) => {
     return a.id !== ownProps.fromAccount.id
   }).sort((a, b) => a.name > b.name ? 1 : -1),
   rates: state.rates

--- a/src/components/accounts/WithdrawDialog.js
+++ b/src/components/accounts/WithdrawDialog.js
@@ -59,7 +59,7 @@ class WithdrawDialog extends React.Component {
     })
 
     this.props.addHistory({
-      text: `Withdrew ${this.state.value} ${this.props.account.currency} from\
+      text: `Withdrew ${this.state.value} ${this.props.account.currency} from \
         ${this.props.account.name}`,
       date: moment().format()
     })

--- a/src/components/common/TotalBalanceOrProgress.js
+++ b/src/components/common/TotalBalanceOrProgress.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import CircularProgress from '@material-ui/core/CircularProgress'
 
 import { getTotalBalance } from '../../lib/helpers'
+import { getAllAccounts } from '../../redux/reducers/accounts'
 
 const TotalBalanceOrProgress = ({ total }) =>  (
   <>
@@ -20,7 +21,7 @@ TotalBalanceOrProgress.propTypes = {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const accounts = ownProps.accounts || state.accounts
+  const accounts = ownProps.accounts || getAllAccounts(state.accounts)
   return {
     total: getTotalBalance(accounts, state.rates, state.settings.defaultCurrency)
   }

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -13,3 +13,18 @@ export const getTotalBalance = (accounts, rates, defaultCurrency) => {
     return res + Number(account.value) / defaultRates[account.currency]
   }, 0).toFixed(2) + ' ' + defaultCurrency
 }
+
+// This updates any old store array formats to the new normalized structure
+export const normalizeState = (state) => {
+  if (!Array.isArray(state)) {
+    return state
+  }
+
+  return {
+    byId: state.reduce((res, item) => {
+      res[item.id] = item
+      return res
+    }, {}),
+    allIds: state.map((item) => item.id)
+  }
+}

--- a/src/redux/reducers/accounts.js
+++ b/src/redux/reducers/accounts.js
@@ -1,69 +1,93 @@
-export default (state = [], action) => {
+import { combineReducers } from 'redux'
+
+const byId = (state = {}, action) => {
   switch (action.type) {
     case 'ADD_ACCOUNT': {
-      return [...state, action.payload]
+      return {
+        ...state,
+        [action.payload.id]: action.payload
+      }
     }
 
     case 'EDIT_ACCOUNT': {
-      return state.map((account) => {
-        if (account.id === action.payload.id) {
-          return {
-            ...account,
-            ...action.payload
-          }
+      return {
+        ...state,
+        [action.payload.id]: {
+          ...state[action.payload.id],
+          ...action.payload
         }
-        return account
-      })
+      }
     }
 
     case 'DELETE_ACCOUNT': {
-      return state.filter((account) => account.id !== action.payload)
+      const newState = { ...state }
+      delete newState[action.payload.id]
+      return newState
     }
 
     case 'MAKE_DEPOSIT': {
-      return state.map((account) => {
-        if (account.id === action.payload.accountId) {
-          return {
-            ...account,
-            value: Number(account.value) + action.payload.value
-          }
+      const account = state[action.payload.accountId]
+
+      return {
+        ...state,
+        [action.payload.accountId]: {
+          ...account,
+          value: Number(account.value) + action.payload.value
         }
-        return account
-      })
+      }
     }
   
     case 'MAKE_WITHDRAWAL': {
-      return state.map((account) => {
-        if (account.id === action.payload.accountId) {
-          return {
-            ...account,
-            value: Math.max(0, Number(account.value) - action.payload.value)
-          }
+      const account = state[action.payload.accountId]
+
+      return {
+        ...state,
+        [action.payload.accountId]: {
+          ...account,
+          value: Math.max(0, Number(account.value) - action.payload.value)
         }
-        return account
-      })
+      }
     }
   
     case 'MAKE_TRANSFER': {
-      return state.map((account) => {
-        if (account.id === action.payload.fromAccountId) {
-          return {
-            ...account,
-            value: Math.max(0, Number(account.value) - action.payload.fromAccountValue)
-          }
+      const fromAccount = state[action.payload.fromAccountId]
+      const toAccount = state[action.payload.toAccountId]
+
+      return {
+        ...state,
+        [action.payload.fromAccountId]: {
+          ...fromAccount,
+          value: Math.max(0, Number(fromAccount.value) - action.payload.fromAccountValue)
+        },
+        [action.payload.toAccountId]: {
+          ...toAccount,
+          value: Number(toAccount.value) + action.payload.toAccountValue
         }
-  
-        if (account.id === action.payload.toAccountId) {
-          return {
-            ...account,
-            value: Number(account.value) + action.payload.toAccountValue
-          }
-        }
-        return account
-      })
+      }
     }
 
     default:
       return state
   }
 }
+
+const allIds = (state = [], action) => {
+  switch (action.type) {
+    case 'ADD_ACCOUNT': {
+      return [...state, action.payload.id]
+    }
+    case 'DELETE_ACCOUNT': {
+      return state.filter((id) => id !== action.payload.id)
+    }
+    default:
+      return state
+  }
+}
+
+export default combineReducers({
+  byId,
+  allIds
+})
+
+export const getAllAccounts = (state) =>
+  state.allIds.map((id) => state.byId[id])

--- a/src/redux/reducers/groups.js
+++ b/src/redux/reducers/groups.js
@@ -1,31 +1,50 @@
+import { combineReducers } from 'redux'
 import { uniqueId } from '../../lib/helpers'
 
+// This initialState is used to populate the groups store for the first time,
+// then it goes to the localStorage and will be loaded from there afterwards
 const initialState = [
   'Cash',
   'Cards & Bank Accounts',
   'Debts',
   'Investments',
   'Others'
-].map((name) => ({
-  id: uniqueId(),
-  name
-}))
+].reduce((res, name) => {
+  const id = uniqueId()
+  res.byId[id] = {
+    id,
+    name
+  }
+  res.allIds.push(id)
+  return res
+}, {
+  byId: {},
+  allIds: []
+})
 
-export default (state = initialState, action) => {
+const byId = (state = initialState.byId, action) => {
   switch (action.type) {
     case 'TOGGLE_GROUP': {
-      return state.map((group) => {
-        if (group.id === action.payload.groupId) {
-          return {
-            ...group,
-            collapsed: action.payload.collapsed
-          }
+      return {
+        ...state,
+        [action.payload.groupId]: {
+          ...state[action.payload.groupId],
+          collapsed: action.payload.collapsed
         }
-        return group
-      })
+      }
     }
 
     default:
       return state
   }
 }
+
+const allIds = (state = initialState.allIds) => state
+
+export default combineReducers({
+  byId,
+  allIds
+})
+
+export const getAllGroups = (state) =>
+  state.allIds.map((id) => state.byId[id])

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -5,7 +5,7 @@ import groups from './groups'
 import history from './history'
 import rates from './rates'
 import settings from './settings'
-import { uniqueId } from '../../lib/helpers'
+import { uniqueId, normalizeState } from '../../lib/helpers'
 
 const allReducers = combineReducers({
   accounts,
@@ -24,24 +24,24 @@ export default (state, action) => {
   if (action.type === 'LOAD_DEMO_DATA') {
     state = {
       ...state,
-      accounts: [
+      accounts: normalizeState([
         // Cash
-        { name: 'Wallet', id: uniqueId(), currency: 'USD', value: 500, groupId: state.groups[0].id },
-        { name: 'Travel Change', id: uniqueId(), currency: 'EUR', value: 95, groupId: state.groups[0].id },
+        { name: 'Wallet', id: uniqueId(), currency: 'USD', value: 500, groupId: state.groups.allIds[0] },
+        { name: 'Travel Change', id: uniqueId(), currency: 'EUR', value: 95, groupId: state.groups.allIds[0] },
 
         // Cards & Bank Accounts
-        { name: 'Debit Card', id: uniqueId(), currency: 'USD', value: 8500, groupId: state.groups[1].id },
-        { name: 'TransferWise', id: uniqueId(), currency: 'USD', value: 1500, groupId: state.groups[1].id },
-        { name: 'Canadian Account', id: uniqueId(), currency: 'CAD', value: 500, groupId: state.groups[1].id },
+        { name: 'Debit Card', id: uniqueId(), currency: 'USD', value: 8500, groupId: state.groups.allIds[1] },
+        { name: 'TransferWise', id: uniqueId(), currency: 'USD', value: 1500, groupId: state.groups.allIds[1] },
+        { name: 'Canadian Account', id: uniqueId(), currency: 'CAD', value: 500, groupId: state.groups.allIds[1] },
 
         // Investments
-        { name: 'P2P Lending', id: uniqueId(), currency: 'EUR', value: 5000, groupId: state.groups[3].id },
-        { name: 'Stocks', id: uniqueId(), currency: 'USD', value: 5000, groupId: state.groups[3].id },
-        { name: 'Crypto funds', id: uniqueId(), currency: 'USD', value: 5000, groupId: state.groups[3].id },
+        { name: 'P2P Lending', id: uniqueId(), currency: 'EUR', value: 5000, groupId: state.groups.allIds[3] },
+        { name: 'Stocks', id: uniqueId(), currency: 'USD', value: 5000, groupId: state.groups.allIds[3] },
+        { name: 'Crypto funds', id: uniqueId(), currency: 'USD', value: 5000, groupId: state.groups.allIds[3] },
 
         // Other Accounts
-        { name: 'PayPal', id: uniqueId(), currency: 'USD', value: 500, groupId: state.groups[4].id }
-      ],
+        { name: 'PayPal', id: uniqueId(), currency: 'USD', value: 500, groupId: state.groups.allIds[4] }
+      ]),
       settings: {
         defaultCurrency: 'USD'
       }

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -3,13 +3,17 @@ import { createStore, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
 
 import reducer from './reducers/index'
+import { normalizeState } from '../lib/helpers'
 
 const initialState = {
-  accounts: [],
+  accounts: {},
   history: [],
   rates: {},
   ...JSON.parse(localStorage.getItem('reactwallet'))
 }
+
+initialState.accounts = normalizeState(initialState.accounts)
+initialState.groups = normalizeState(initialState.groups)
 
 const store = createStore(
   reducer,


### PR DESCRIPTION
The redux store is normalized for the accounts and the groups arrays
and now they'll both look like this:
{
  byId: {
   x: {...},
   y: {...},
   ...
  },
  allIds: ['x', 'y', ...]
}

Old structures saved in the localStorage will be automatically updated
to the new normalized structure when the app is reloaded.